### PR TITLE
Remove an unnecessary require call to NFP

### DIFF
--- a/src/interfaces/FileParser.js
+++ b/src/interfaces/FileParser.js
@@ -8,7 +8,6 @@
 module.exports = (function() {
 
     var fs = require('fs');
-    var NodeFileParser = require('../NodeFileParser');
 
     /**
      * Creates a new FileParser.


### PR DESCRIPTION
This circular dependency was not used and caused issues on Node 5.
